### PR TITLE
chore: upgrade numpy and matplotlib to the newest version possible

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,9 @@ import sys
 sys.path.insert(0, os.path.abspath(".."))
 
 project = 'heatrapy'
-copyright = '2024, Daniel Silva'
+copyright = '2026, Daniel Silva'
 author = 'Daniel Silva'
-release = '2.0.14'
+release = '2.1.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ incorporation of phase transitions.
 
 |icon_github|  `github repository <https://github.com/djsilva99/heatrapy>`_
 
-|icon_heatrapy|  current version: v2.0.14
+|icon_heatrapy|  current version: v2.1.0
 
 .. |icon_github| image:: https://github.githubassets.com/favicons/favicon.png
    :width: 25px

--- a/heatrapy/__init__.py
+++ b/heatrapy/__init__.py
@@ -1,7 +1,7 @@
 """Heatrapy.
 
 author: Daniel Silva (djsilva@gmx.com)
-current version: v2.0.14
+current version: v2.1.0
 url: https://github.com/djsilva99/heatrapy
 
 This module allows to create thermal objects, establish thermal contact between

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ cycler==0.10.0
 exceptiongroup==1.2.2
 iniconfig==2.0.0
 kiwisolver==1.3.1
-matplotlib==3.7.5
-numpy==1.26.4
+matplotlib==3.10.8
+numpy==2.2.6
 packaging==24.1
 Pillow==12.1.1
 pluggy==1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ numpy==2.2.6
 packaging==24.1
 Pillow==12.1.1
 pluggy==1.5.0
-pyparsing==2.4.7
+pyparsing==3.1.0
 pytest==8.3.3
 pytest-cov==5.0.0
 python-dateutil==2.8.1

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ description += 'package includes the incorporation of phase transitions.'
 
 
 setup(name='heatrapy',
-      version='2.0.14',
+      version='2.1.0',
       description='Library for simulating 1D and 2D heat transfer processes',
       long_description=description,
       classifiers=[
@@ -31,7 +31,7 @@ setup(name='heatrapy',
       license='MIT',
       packages=['heatrapy'],
       install_requires=[
-          'numpy==1.26.4', 'matplotlib==3.7.5'
+          'numpy==2.2.6', 'matplotlib==3.10.8'
       ],
       include_package_data=True,
       zip_safe=False)


### PR DESCRIPTION
## What
This PR upgrades numpy and matplotlib to the newest versions possible:
matplotlib==3.10.8
numpy==2.2.6
pyparsing==3.1.0

This PR also prepares the new release v2.1.0.

## Why
There are some version issues when trying to install using conda + pip. This PR prepares the integration with conda.