### PR TITLE
fix: use minimum version bounds for dependencies instead of exact pins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ setup(
     packages=['heatrapy'],
     python_requires='>=3.10',
     install_requires=[
-        'numpy>=1.22',
-        'matplotlib>=3.5',
+        'numpy>=1.22,<3',
+        'matplotlib>=3.5,<4',
     ],
     include_package_data=True,
     zip_safe=False

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,10 @@ setup(
     author_email='djsilva@gmx.com',
     license='MIT',
     packages=['heatrapy'],
+    python_requires='>=3.10',
     install_requires=[
-        'numpy==2.4.2',
-        'matplotlib==3.10.8'
+        'numpy>=1.22',
+        'matplotlib>=3.5',
     ],
     include_package_data=True,
     zip_safe=False


### PR DESCRIPTION
Closes #69
 
### Problem
 
`install_requires` pins exact versions (`numpy==2.4.2`, `matplotlib==3.10.8`).
For a library this breaks user environments by forcing downgrades or conflicts
with other packages. The user in #69 had their conda environment broken by this.
 
### Fix
 
Changed `==` to `>=` with reasonable lower bounds:
 
- `numpy>=1.22` (first version to support Python 3.10, which is required
  by the `int | float` type hints used throughout the codebase)
- `matplotlib>=3.5` (first version compatible with numpy 1.22+)
 
Also added `python_requires='>=3.10'` since the code uses union type syntax
(`int | float`) which was introduced in Python 3.10.
 
The `requirements.txt` is left unchanged — exact pins there are fine for
development/CI reproducibility.
 
### Note
 
While looking at this I noticed `packages=['heatrapy']` doesn't include
subpackages (`dimension_1`, `dimension_2`, `mats`, etc.). This means
`pip install heatrapy` from a wheel/sdist might be missing them. Using
`find_packages()` would fix this. Happy to open a separate issue/PR for that.
 